### PR TITLE
apply Sonatype rebranding

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,5 +1,5 @@
 # Some profiles have a reverse proxy provided by nGinx.
-# This is the version of nGinx to use:
+# This is the version of NGINX to use:
 NGINX_VERSION=1.23.3
 
 # PostgreSQL data
@@ -35,7 +35,7 @@ DOCKER_ROOT_VOLUME_MOUNT_POINT=./data
 # If you have a valid Sonatype License File, set the full path to it here
 NEXUS_LICENSE_PATH=./config/sonatype-license-all.lic
 
-# If you want to access your Nexus Repository or Nexus IQ Server via a FQDN, set these here!
+# If you want to access your Nexus Repository or Sonatype IQ Server via a FQDN, set these here!
 # If you are using nGrok - absolutely it is best practice to set these FQDNs here.
 #NXRM_FQDN_URL=
 #NXLC_FQDN_URL=

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Nexus Platform on Docker
+# Sonatype Platform on Docker
 
-This repo contains `docker-compose` files associated sample configuration for quickly standing up a number of *Reference Architectures* for the Nexus Platform components.
+This repo contains `docker-compose` files associated sample configuration for quickly standing up a number of *Reference Architectures* for the Sonatype Platform components.
 
 Ideal if you want to get hands on quickly :-)
 
@@ -8,22 +8,20 @@ Unless you have a license from [Sonatype](https://www.sonatype.com), you will on
 
 If you don't have a trial license and would like one [contact Sonatype](https://www.sonatype.com).
 
-# What is the Nexus Platform?
+# What is the Sonatype Platform?
 
-When we refer to the Nexus Platform, we actually refer to three of Sonatype's core-products and their associated add-on packs. These are:
+When we refer to the Sonatype Platform, we actually refer to three of Sonatype's core-products and their associated add-on packs. These are:
 
-1. Nexus Repository (either [Nexus Repository OSS](https://www.sonatype.com/products/repository-oss) or [Nexus Repository Pro](https://www.sonatype.com/products/repository-pro?))
-2. [Nexus Lifecycle](https://www.sonatype.com/products/open-source-security-dependency-management) and it's add-on packs:
-    - [Advanced Development Pack](https://www.sonatype.com/product/advanced-development-pack)
+1. Nexus Repository (either [Nexus Repository OSS](https://www.sonatype.com/products/repository-oss) or [Nexus Repository Pro](https://www.sonatype.com/products/repository-pro))
+2. [Sonatype Lifecycle](https://www.sonatype.com/products/open-source-security-dependency-management) and its add-on packs:
     - [Advanced Legal Pack](https://www.sonatype.com/products/advanced-legal-pack)
-    - [Infrastructure as Code Pack](https://www.sonatype.com/product/infrastructure-as-code)
-3. [Nexus Firewall](https://www.sonatype.com/products/firewall)
+3. [Sonatype Repository Firewall](https://www.sonatype.com/products/sonatype-repository-firewall)
 
 For the full suite of products - check out [www.sonatype.com](https://www.sonatype.com).
 
 # How does this code work?
 
-We utilise [docker-compose profiles](https://docs.docker.com/compose/profiles/) to allow you to quickly stand up the required containers to realise a specific refernece architecture.
+We utilise [docker-compose profiles](https://docs.docker.com/compose/profiles/) to allow you to quickly stand up the required containers to realise a specific reference architecture.
 
 Assuming you have [Docker Desktop](https://www.docker.com/products/docker-desktop) 19.03.0+ (or similar) installed, you can simply run `docker-compose` passing the required profile. An example using the `proxied` profile might be:
 
@@ -33,7 +31,7 @@ docker-compose --profile=proxied up -d
 
 # Providing your Sonatype License
 
-For most of the reference architecutres, you'll need a Sonatype license. If you have this, (it's a `.lic`) file you can use it through one of two methods:
+For most of the reference architectures, you'll need a Sonatype license. If you have this (it's a `.lic` file), you can use it through one of two methods:
 
 1. Put your `.lic` file in `config/sonatype-license-all.lic`
 2. Modify the path to your `.lic` file in the `.env` file:
@@ -43,10 +41,10 @@ For most of the reference architecutres, you'll need a Sonatype license. If you 
 
 # Reference Architecture Profiles
 
-| Profile Name    | License Required | Nexus Platform                                | Nexus Repo                               | Nexus Lifecycle                        | Description                                                                                           |
+| Profile Name    | License Required | Sonatype Platform                             | Nexus Repo                               | Sonatype Lifecycle                     | Description                                                                                           |
 | --------------- | ---------------- | --------------------------------------------- | ---------------------------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `proxied`       | Yes              | Yes - [here](http://nexus-platform.localhost) | Yes [here](http://repo.localhost/)       | Yes [here](http://iq.localhost/)       | Both Nexus Repository Pro and Nexus Lifecycle available behind an nGinx reverse proxy.                |
-| `direct`        | Yes              | No                                            | Yes - [here](http://repo.localhost:8081) | Yes - [here](http://iq.localhost:8070) | Both Nexus Repository Pro and Nexus Lifecycle available directly via `localhost` addressed over HTTP. |
+| `proxied`       | Yes              | Yes - [here](http://nexus-platform.localhost) | Yes [here](http://repo.localhost/)       | Yes [here](http://iq.localhost/)       | Both Nexus Repository Pro and Sonatype Lifecycle available behind an NGINX reverse proxy.                |
+| `direct`        | Yes              | No                                            | Yes - [here](http://repo.localhost:8081) | Yes - [here](http://iq.localhost:8070) | Both Nexus Repository Pro and Sonatype Lifecycle available directly via `localhost` addressed over HTTP. |
 | `repoOssDemo`   | No               | No                                            | Yes - [here](http://repo.localhost:8081) | No                                     | Nexus Repo OSS will be started.                                                                       |
 | `cicd-jenkins`  | Yes              | Yes - [here](http://nexus-platform.localhost) | Yes [here](http://repo.localhost/)       | Yes [here](http://iq.localhost/)       | Includes a Jenkins [here](http://nexus-platform/jenkins)                                              |
 | `cicd-teamcity` | Yes              | Yes - [here](http://nexus-platform.localhost) | Yes [here](http://repo.localhost/)       | Yes [here](http://iq.localhost/)       | Includes a TeamCity Server [here](http://nexus-platform/teamcity)                                     |
@@ -81,4 +79,4 @@ Remember:
 - DO file issues here on GitHub, so that the community can pitch in
 - Phew, that was easier than I thought. Last but not least of all:
 
-Have fun creating and using this utility to quikcly get hands-on with Nexus Repository and Nexus Lifecycle. We are glad to have you here!
+Have fun creating and using this utility to quikcly get hands-on with Nexus Repository and Sonatype Lifecycle. We are glad to have you here!

--- a/config/nexus-iq-config.yaml
+++ b/config/nexus-iq-config.yaml
@@ -81,8 +81,8 @@ server:
         # The number of archived files to keep.
         archivedFileCount: 5
 # Notification JIRA settings.
-# Note that any user of the Nexus IQ Server will have access to see all projects and applicable issue types available
-# to the configured JIRA account. More details available in the Nexus IQ Server documentation. If enabled, ensure that
+# Note that any user of the Sonatype IQ Server will have access to see all projects and applicable issue types available
+# to the configured JIRA account. More details available in the Sonatype IQ Server documentation. If enabled, ensure that
 # the baseUrl configuration setting is also enabled and correct, because generated tickets contain links to the server.
 #jira:
 # The JIRA server address

--- a/config/nginx-cicd-teamcity.conf
+++ b/config/nginx-cicd-teamcity.conf
@@ -18,7 +18,7 @@ http {
     '' close;
   }
 
-  # Default Virtual Host for "Nexus Platform" landing page
+  # Default Virtual Host for "Sonatype Platform" landing page
   # ------------------------------------------------------
   server {
     listen                  80 default;
@@ -65,7 +65,7 @@ http {
     }
   }
 
-  # Virtual Host to proxy to Nexus Lifecycle
+  # Virtual Host to proxy to Sonatype Lifecycle
   # ------------------------------------------------------
   server {
     listen                  80;

--- a/config/nginx-cicd.conf
+++ b/config/nginx-cicd.conf
@@ -23,7 +23,7 @@ http {
     '' close;
   }
 
-  # Default Virtual Host for "Nexus Platform" landing page
+  # Default Virtual Host for "Sonatype Platform" landing page
   # ------------------------------------------------------
   server {
     listen                  80 default;
@@ -100,7 +100,7 @@ http {
     }
   }
 
-  # Virtual Host to proxy to Nexus Lifecycle
+  # Virtual Host to proxy to Sonatype Lifecycle
   # ------------------------------------------------------
   server {
     listen                  80;

--- a/config/nginx-www-template/index.html.template
+++ b/config/nginx-www-template/index.html.template
@@ -1,7 +1,7 @@
 <html>
 
 <head>
-    <title>Nexus Platform on Docker</title>
+    <title>Sonatype Platform on Docker</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
 </head>
@@ -26,7 +26,7 @@
             <polygon class="cls-1" points="19.44 0 19.44 5.25 31.73 12.35 36.27 9.73 19.44 0" />
         </symbol>
         <symbol id="nexus_lifecycle_logo" viewBox="0 0 37 42.25">
-            <title>Nexus Lifecycle</title>
+            <title>Sonatype Lifecycle</title>
             <style>
                 .cls-3 {
                     fill: #0666f2;
@@ -43,7 +43,7 @@
             <polygon class="cls-3" points="19.44 37.02 19.44 42.25 36.27 32.55 31.73 29.93 19.44 37.02" />
         </symbol>
         <symbol id="nexus_firewall" viewBox="0 0 37 42.25">
-            <title>Nexus Firewall</title>
+            <title>Sonatype Repository Firewall</title>
             <style>
                 .cls-4 {
                     fill: #a830c2;
@@ -62,10 +62,10 @@
     </svg>
 
     <main>
-        <h1 class="visually-hidden">Nexus Platform on Docker</h1>
+        <h1 class="visually-hidden">Sonatype Platform on Docker</h1>
 
         <div class="container px-4 py-5">
-            <h2 class="pb-2 border-bottom"><em>Your</em> Nexus Platform on Docker</h2>
+            <h2 class="pb-2 border-bottom"><em>Your</em> Sonatype Platform on Docker</h2>
             <div class="row g-4 py-5 row-cols-1 row-cols-lg-2">
                 <div class="col d-flex align-items-start border-end">
                     <div class="icon-square bg-light text-dark flex-shrink-0 me-3">
@@ -110,10 +110,10 @@
                         </svg>
                     </div>
                     <div>
-                        <h2>Nexus Lifecycle <span class="badge rounded-pill bg-success">$NEXUS_IQ_SERVER_VERSION</span></h2>
+                        <h2>Sonatype Lifecycle <span class="badge rounded-pill bg-success">$NEXUS_IQ_SERVER_VERSION</span></h2>
                         <p>Eliminate OSS risk across the entire SDLC.</p>
                         <a href="http://iq.localhost" target="_blank" class="btn btn-primary">
-                            Access Nexus Lifecycle
+                            Access Sonatype Lifecycle
                         </a>
                         <dl class="row mt-4">
                             <dt class="col-sm-3">Product Details</dt>
@@ -125,7 +125,7 @@
 
                             <dt class="col-sm-3">Documentation</dt>
                             <dd class="col-sm-9">
-                                <a href="https://help.sonatype.com/iqserver" target="_blank">Nexus IQ Server</a>
+                                <a href="https://help.sonatype.com/iqserver" target="_blank">Sonatype IQ Server</a>
                             </dd>
 
                             <dt class="col-sm-3">Guides</dt>

--- a/config/nginx-www/index.html
+++ b/config/nginx-www/index.html
@@ -1,7 +1,7 @@
 <html>
 
 <head>
-    <title>Nexus Platform on Docker</title>
+    <title>Sonatype Platform on Docker</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
 </head>
@@ -26,7 +26,7 @@
             <polygon class="cls-1" points="19.44 0 19.44 5.25 31.73 12.35 36.27 9.73 19.44 0" />
         </symbol>
         <symbol id="nexus_lifecycle_logo" viewBox="0 0 37 42.25">
-            <title>Nexus Lifecycle</title>
+            <title>Sonatype Lifecycle</title>
             <style>
                 .cls-3 {
                     fill: #0666f2;
@@ -43,7 +43,7 @@
             <polygon class="cls-3" points="19.44 37.02 19.44 42.25 36.27 32.55 31.73 29.93 19.44 37.02" />
         </symbol>
         <symbol id="nexus_firewall" viewBox="0 0 37 42.25">
-            <title>Nexus Firewall</title>
+            <title>Sonatype Repository Firewall</title>
             <style>
                 .cls-4 {
                     fill: #a830c2;
@@ -62,10 +62,10 @@
     </svg>
 
     <main>
-        <h1 class="visually-hidden">Nexus Platform on Docker</h1>
+        <h1 class="visually-hidden">Sonatype Platform on Docker</h1>
 
         <div class="container px-4 py-5">
-            <h2 class="pb-2 border-bottom"><em>Your</em> Nexus Platform on Docker</h2>
+            <h2 class="pb-2 border-bottom"><em>Your</em> Sonatype Platform on Docker</h2>
             <div class="row g-4 py-5 row-cols-1 row-cols-lg-2">
                 <div class="col d-flex align-items-start border-end">
                     <div class="icon-square bg-light text-dark flex-shrink-0 me-3">
@@ -114,12 +114,12 @@
                         </svg>
                     </div>
                     <div>
-                        <h2>Nexus Lifecycle
+                        <h2>Sonatype Lifecycle
                             <!--<span class="badge rounded-pill bg-success">1.121.0</span>-->
                         </h2>
                         <p>Eliminate OSS risk across the entire SDLC.</p>
                         <a href="http://iq.localhost" target="_blank" class="btn btn-primary">
-                            Access Nexus Lifecycle
+                            Access Sonatype Lifecycle
                         </a>
                         <dl class="row mt-4">
                             <dt class="col-sm-3">Product Details</dt>
@@ -131,7 +131,7 @@
 
                             <dt class="col-sm-3">Documentation</dt>
                             <dd class="col-sm-9">
-                                <a href="https://help.sonatype.com/iqserver" target="_blank">Nexus IQ Server</a>
+                                <a href="https://help.sonatype.com/iqserver" target="_blank">Sonatype IQ Server</a>
                             </dd>
 
                             <dt class="col-sm-3">Guides</dt>

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -19,7 +19,7 @@ http {
     '' close;
   }
 
-  # Default Virtual Host for "Nexus Platform" landing page
+  # Default Virtual Host for "Sonatype Platform" landing page
   # ------------------------------------------------------
   server {
     listen                  80 default;
@@ -86,7 +86,7 @@ http {
     }
   }
 
-  # Virtual Host to proxy to Nexus Lifecycle
+  # Virtual Host to proxy to Sonatype Lifecycle
   # ------------------------------------------------------
   server {
     listen                  80;


### PR DESCRIPTION
`nexus-platform.localhost` could eventually be renamed to `sonatype-platform.localhost` and other technical ids, but in a second step