### PR TITLE
fix: IQ connection to PostgreSQL added in 8e50c5a

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -3,8 +3,6 @@
 NGINX_VERSION=1.23.3
 
 # PostgreSQL data
-POSTGRES_PASSWORD=Letmin123
-PG_DB_HOST=localhost
 PG_DB_PORT=5432
 PG_DB_NAME=nxiq
 PG_DB_USER=nxiq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     environment:
       JAVA_OPTS: "-Ddw.baseUrl=${NXLC_FQDN_URL:-http://iq.localhost:8070} -Djava.util.prefs.userRoot=/sonatype-work/javaprefs"
       DATABASE_TYPE: postgresql
-      DATABASE_HOSTNAME: ${PG_DB_HOST:?err}
+      DATABASE_HOSTNAME: postgres
       DATABASE_PORT: ${PG_DB_PORT:-5432}
       DATABASE_NAME: ${PG_DB_NAME:?err}
       DATABASE_USERNAME: ${PG_DB_USER:?err}
@@ -60,6 +60,9 @@ services:
       - "./config/nexus-iq-config.yaml:/etc/nexus-iq-server/config.yml:delegated"
       - "${DOCKER_ROOT_VOLUME_MOUNT_POINT:?err}/iq-data:/sonatype-work:delegated"
       - "${DOCKER_ROOT_VOLUME_MOUNT_POINT:?err}/iq-logs:/opt/sonatype/nexus-iq-server/log:delegated"
+    depends_on:
+      postgres:
+        condition: service_healthy
 
   nxiq-proxied:
     image: "${NEXUS_DOCKER_IMAGE_ORGANIZATION}/nexus-iq-server:${NEXUS_IQ_SERVER_VERSION:?err}"
@@ -159,12 +162,19 @@ services:
   postgres:
     image: "postgres:16.0-alpine3.18"
     environment:
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_USER=${PG_DB_USER:?err}
+      - POSTGRES_PASSWORD=${PG_DB_PASS:?err}
+      - POSTGRES_DB=${PG_DB_NAME:?err}
       - PGDATA=/var/lib/postgresql/data/pgdata
     ports:
       - '5432:5432'
     volumes:
       - *pgsql-volume-data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${PG_DB_USER:?err}"]
+      interval: 1s
+      timeout: 5s
+      retries: 10
 
   proxy:
     image: "nginx:${NGINX_VERSION:?err}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,12 @@ services:
     image: "${NEXUS_DOCKER_IMAGE_ORGANIZATION}/nexus-iq-server:${NEXUS_IQ_SERVER_VERSION:?err}"
     environment:
       JAVA_OPTS: "-Ddw.baseUrl=${NXLC_FQDN_URL:-http://iq.localhost} -Djava.util.prefs.userRoot=/sonatype-work/javaprefs"
+      DATABASE_TYPE: postgresql
+      DATABASE_HOSTNAME: postgres
+      DATABASE_PORT: ${PG_DB_PORT:-5432}
+      DATABASE_NAME: ${PG_DB_NAME:?err}
+      DATABASE_USERNAME: ${PG_DB_USER:?err}
+      DATABASE_PASSWORD: ${PG_DB_PASS:?err}
     networks:
       - platform
     profiles:
@@ -81,6 +87,9 @@ services:
       - "./config/nexus-iq-config.yaml:/etc/nexus-iq-server/config.yml:delegated"
       - "${DOCKER_ROOT_VOLUME_MOUNT_POINT:?err}/iq-data:/sonatype-work:delegated"
       - "${DOCKER_ROOT_VOLUME_MOUNT_POINT:?err}/iq-logs:/opt/sonatype/nexus-iq-server/log:delegated"
+    depends_on:
+      postgres:
+        condition: service_healthy
 
   nxrm3_direct:
     image: "${NEXUS_DOCKER_IMAGE_ORGANIZATION}/nexus3:${NEXUS_REPOSITORY_VERSION:?err}"


### PR DESCRIPTION
testing run from fresh clone and cleanup at end:
```
cat .env-example | sed 's/ORGANIZATION=sonatype/ORGANIZATION=sonatypecommunity/' > .env 
docker-compose --profile=direct up
\rm -rf data/*
```
result: IQ Server cannot not connect DB because Docker compose internal network does not name the DB host "localhost" but with the service name = postgres in our case, and db is not ready when IQ tries to use

log on console:
```
WARN[0000] /Users/hboutemy/dev/tmp/nexus-platform-reference/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
[+] Running 3/0
 ✔ Container nexus-platform-reference-postgres-1      Created                                                                                                                                                                                                         0.0s
 ✔ Container nexus-platform-reference-nxrm3_direct-1  Created                                                                                                                                                                                                         0.0s
 ✔ Container nexus-platform-reference-nxiq_direct-1   Created                                                                                                                                                                                                         0.0s
Attaching to nxiq_direct-1, nxrm3_direct-1, postgres-1
postgres-1      | The files belonging to this database system will be owned by user "postgres".
postgres-1      | This user must also own the server process.
postgres-1      |
postgres-1      | The database cluster will be initialized with locale "en_US.utf8".
postgres-1      | The default database encoding has accordingly been set to "UTF8".
postgres-1      | The default text search configuration will be set to "english".
postgres-1      |
postgres-1      | Data page checksums are disabled.
postgres-1      |
postgres-1      | fixing permissions on existing directory /var/lib/postgresql/data/pgdata ... ok
postgres-1      | creating subdirectories ... ok
postgres-1      | selecting dynamic shared memory implementation ... posix
postgres-1      | selecting default max_connections ... 100
postgres-1      | selecting default shared_buffers ... 128MB
postgres-1      | selecting default time zone ... UTC
postgres-1      | creating configuration files ... ok
nxiq_direct-1   | Starting Nexus IQ Server 1 release 168.0-01 instance ID 492bad62-f56f-4d7b-88b1-2f35208ea5af on hostname b30998e1e9ab (IP address 172.25.0.3).
postgres-1      | running bootstrap script ... ok
postgres-1      | sh: locale: not found
postgres-1      | 2024-10-11 12:36:00.651 UTC [31] WARNING:  no usable system locales were found
nxiq_direct-1   | 2024-10-11 12:36:00,768+0000 INFO [main] *SYSTEM com.sonatype.insight.brain.service.InsightBrainService - |------------------------------------------
nxiq_direct-1   | 2024-10-11 12:36:00,769+0000 INFO [main] *SYSTEM com.sonatype.insight.brain.service.InsightBrainService - |
nxiq_direct-1   | 2024-10-11 12:36:00,769+0000 INFO [main] *SYSTEM com.sonatype.insight.brain.service.InsightBrainService - | Initializing Nexus IQ Server 1 release 168.0-01 build build-number
nxiq_direct-1   | 2024-10-11 12:36:00,769+0000 INFO [main] *SYSTEM com.sonatype.insight.brain.service.InsightBrainService - |
nxiq_direct-1   | 2024-10-11 12:36:00,769+0000 INFO [main] *SYSTEM com.sonatype.insight.brain.service.InsightBrainService - |------------------------------------------
nxiq_direct-1   | 2024-10-11 12:36:00,772+0000 INFO [main] *SYSTEM com.sonatype.insight.brain.service.InsightBrainService - Configuration file: /etc/nexus-iq-server/config.yml
nxiq_direct-1   | 2024-10-11 12:36:00,776+0000 INFO [main] *SYSTEM org.eclipse.jetty.util.log - Logging initialized @912ms to org.eclipse.jetty.util.log.Slf4jLog
nxiq_direct-1   | 2024-10-11 12:36:00,803+0000 INFO [main] *SYSTEM io.dropwizard.server.DefaultServerFactory - Registering jersey handler with root path prefix: /
nxiq_direct-1   | 2024-10-11 12:36:00,803+0000 INFO [main] *SYSTEM io.dropwizard.server.DefaultServerFactory - Registering admin handler with root path prefix: /
nxiq_direct-1   | 2024-10-11 12:36:00,804+0000 INFO [main] *SYSTEM io.dropwizard.assets.AssetsBundle - Registering AssetBundle with name: assets for path /assets/*
nxiq_direct-1   | 2024-10-11 12:36:00,804+0000 INFO [main] *SYSTEM io.dropwizard.assets.AssetsBundle - Registering AssetBundle with name: policyAssets for path /policy-assets/*
nxiq_direct-1   | Started Nexus IQ Server 1 release 168.0-01 instance ID 492bad62-f56f-4d7b-88b1-2f35208ea5af on hostname b30998e1e9ab (IP address 172.25.0.3).
nxiq_direct-1   | 2024-10-11 12:36:00,806+0000 INFO [main] *SYSTEM com.sonatype.insight.brain.service.InsightBrainService - Started Nexus IQ Server 1 release 168.0-01 instance ID 492bad62-f56f-4d7b-88b1-2f35208ea5af on hostname b30998e1e9ab (IP address 172.25.0.3).
nxiq_direct-1   | 2024-10-11 12:36:00,806+0000 INFO [main] *SYSTEM com.sonatype.insight.brain.service.DatabaseConfigProvider - Using external database at localhost
nxiq_direct-1   | 2024-10-11 12:36:00,807+0000 INFO [main] *SYSTEM com.sonatype.insight.brain.db.datastore.DefaultOperationalDataStore - Initializing the insight_brain_ods data store.
nxiq_direct-1   | Stopping Nexus IQ Server 1 release 168.0-01 instance ID 492bad62-f56f-4d7b-88b1-2f35208ea5af on hostname b30998e1e9ab (IP address 172.25.0.3). Uptime: 2024-10-11T12:36:00.023Z
nxiq_direct-1   | 2024-10-11 12:36:00,860+0000 ERROR [main] *SYSTEM com.sonatype.insight.brain.service.InsightBrainService - Fatal error trying to start server
nxiq_direct-1   | java.lang.IllegalStateException: Fatal error trying to start server
nxiq_direct-1   | 	at com.sonatype.insight.brain.service.InsightBrainService$2.onError(InsightBrainService.java:215)
nxiq_direct-1   | 	at io.dropwizard.cli.Cli.run(Cli.java:82)
nxiq_direct-1   | 	at com.sonatype.insight.brain.service.InsightBrainService.run(InsightBrainService.java:230)
nxiq_direct-1   | 	at com.sonatype.insight.brain.service.InsightBrainService.main(InsightBrainService.java:136)
nxiq_direct-1   | Caused by: com.sonatype.insight.db.DatabaseException: java.sql.SQLException: Cannot create PoolableConnectionFactory (Connection to localhost:5432 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.)
n
```

Using a few reference documentations:
- https://github.com/docker-library/docs/blob/master/postgres/README.md#environment-variables
- https://www.docker.com/blog/how-to-use-the-postgres-docker-official-image/ as a reference for improving